### PR TITLE
Modified execute commands to always use US for the Locale

### DIFF
--- a/src/net/sourceforge/sox/SoxController.java
+++ b/src/net/sourceforge/sox/SoxController.java
@@ -284,6 +284,12 @@ public class SoxController {
 	private int execProcess(List<String> cmds, ShellCallback sc)
 			throws IOException, InterruptedException {
 
+		//ensure that the arguments are in the correct Locale format
+		for (String cmd :cmds)
+		{
+			cmd = String.format(Locale.US, "%s", cmd);
+		}
+		
 		ProcessBuilder pb = new ProcessBuilder(cmds);
 		pb.directory(fileBinDir);
 

--- a/src/org/ffmpeg/android/FfmpegController.java
+++ b/src/org/ffmpeg/android/FfmpegController.java
@@ -75,6 +75,12 @@ public class FfmpegController {
 	
 	private int execProcess(List<String> cmds, ShellCallback sc, File fileExec) throws IOException, InterruptedException {		
         
+		//ensure that the arguments are in the correct Locale format
+		for (String cmd :cmds)
+		{
+			cmd = String.format(Locale.US, "%s", cmd);
+		}
+		
 		ProcessBuilder pb = new ProcessBuilder(cmds);
 		pb.directory(fileExec);
 		
@@ -120,6 +126,9 @@ public class FfmpegController {
 
 	private int execProcess(String cmd, ShellCallback sc, File fileExec) throws IOException, InterruptedException {		
         
+		//ensure that the argument is in the correct Locale format
+		cmd = String.format(Locale.US, "%s", cmd);
+		
 		ProcessBuilder pb = new ProcessBuilder(cmd);
 		pb.directory(fileExec);
 


### PR DESCRIPTION
We were having issues with our generated ffmpeg commands breaking because the Locale was set to China.  Our command strings were containing characters that ffmpeg couldn't interpret.  So instead of checking for the locale at every ffmpeg call, we felt it would be better to handle at the source.
